### PR TITLE
Update Kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.imagegallerysaver'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.51'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.2.51 and higher. Project 'image_gallery_saver' is using version 1.2.30.