### PR TITLE
Fix android 11 permission

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -45,7 +45,7 @@ class ImageGallerySaverPlugin(private val registrar: Registrar): MethodCallHandl
   }
 
   private fun generateFile(extension: String = "", name: String? = null): File {
-    val storePath =  Environment.getExternalStorageDirectory().absolutePath + File.separator + getApplicationName()
+    val storePath =  Environment.getExternalStorageDirectory().absolutePath + File.separator + Environment.DIRECTORY_PICTURES + File.separator + getApplicationName()
     val appDir = File(storePath)
     if (!appDir.exists()) {
       appDir.mkdir()

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -45,7 +45,7 @@ class ImageGallerySaverPlugin(private val registrar: Registrar): MethodCallHandl
   }
 
   private fun generateFile(extension: String = "", name: String? = null): File {
-    val storePath =  Environment.getExternalStorageDirectory().absolutePath + File.separator + Environment.DIRECTORY_PICTURES + File.separator + getApplicationName()
+    val storePath =  Environment.getExternalStorageDirectory().absolutePath + File.separator + Environment.DIRECTORY_PICTURES
     val appDir = File(storePath)
     if (!appDir.exists()) {
       appDir.mkdir()


### PR DESCRIPTION
Also appear in android 10, it can be solved after add `android:requestLegacyExternalStorage="true"` but not working in android 11. The solution is just save file to `Pictures`.

fix #111, fix #112, fix  #143, fix #144