### PR TITLE
Migrate to Null Safety including example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -110,9 +111,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
   _saveScreen() async {
     RenderRepaintBoundary boundary =
-        _globalKey.currentContext.findRenderObject();
+        _globalKey.currentContext!.findRenderObject() as RenderRepaintBoundary;
     ui.Image image = await boundary.toImage();
-    ByteData byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    ByteData byteData = await (image.toByteData(format: ui.ImageByteFormat.png) as FutureOr<ByteData>);
     final result =
         await ImageGallerySaver.saveImage(byteData.buffer.asUint8List());
     print(result);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,18 +10,18 @@ description: Demonstrates how to use the image_gallery_saver plugin.
 version: 1.5.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  permission_handler: ^5.0.1
-  fluttertoast: ^4.0.0
+  permission_handler: ^6.0.1
+  fluttertoast: ^8.0.1-nullsafety.0
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:
@@ -30,8 +30,8 @@ dev_dependencies:
   image_gallery_saver:
     path: ../
 
-  path_provider: ^1.6.11
-  dio: ^3.0.9
+  path_provider: ^2.0.1
+  dio: ^4.0.0-beta6
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/lib/image_gallery_saver.dart
+++ b/lib/image_gallery_saver.dart
@@ -11,7 +11,7 @@ class ImageGallerySaver {
   /// imageBytes can't null
   /// return Map type
   /// for example:{"isSuccess":true, "filePath":String?}
-  static Future saveImage(Uint8List imageBytes,
+  static FutureOr<bool?> saveImage(Uint8List imageBytes,
       {int quality = 80,
       String? name,
       bool isReturnImagePathOfIOS = false}) async {

--- a/lib/image_gallery_saver.dart
+++ b/lib/image_gallery_saver.dart
@@ -13,7 +13,7 @@ class ImageGallerySaver {
   /// for example:{"isSuccess":true, "filePath":String?}
   static Future saveImage(Uint8List imageBytes,
       {int quality = 80,
-      String name,
+      String? name,
       bool isReturnImagePathOfIOS = false}) async {
     assert(imageBytes != null);
     final result =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: quicey <quiceyxu@gmail.com>
 homepage: https://github.com/hui-z/image_gallery_saver
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 dependencies:

--- a/test/image_gallery_saver_test.dart
+++ b/test/image_gallery_saver_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,7 +9,7 @@ void main() {
 
   const MethodChannel channel = MethodChannel('image_gallery_saver');
   final List<MethodCall> log = <MethodCall>[];
-  bool response;
+  bool? response;
 
   channel.setMockMethodCallHandler((MethodCall methodCall) async {
     log.add(methodCall);
@@ -23,7 +24,7 @@ void main() {
   test('saveImageToGallery test', () async {
     response = true;
     Uint8List imageBytes = Uint8List(16);
-    final bool result = await ImageGallerySaver.saveImage(imageBytes);
+    final bool? result = await (ImageGallerySaver.saveImage(imageBytes) as FutureOr<bool?>);
     expect(
       log,
       <Matcher>[


### PR DESCRIPTION
Does full `dart migrate` on the project and the example. Hard to import `dart:async` on `main.dart` for `FutureOr` to work properly

Fixes #152 and migrates more files than #153 