### PR TITLE
Use URL.init to load URL from file path

### DIFF
--- a/ios/Classes/SwiftImageGallerySaverPlugin.swift
+++ b/ios/Classes/SwiftImageGallerySaverPlugin.swift
@@ -49,7 +49,7 @@ public class SwiftImageGallerySaverPlugin: NSObject, FlutterPlugin {
         var videoIds: [String] = []
         
         PHPhotoLibrary.shared().performChanges( {
-            let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL(string: path)!)
+            let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL.init(fileURLWithPath: path))
             if let videoId = req?.placeholderForCreatedAsset?.localIdentifier {
                 videoIds.append(videoId)
             }


### PR DESCRIPTION
Settings `isReturnPathOfIOS` when saving a video file cause Flutter App to crash. 
```dart
 await ImageGallerySaver.saveFile(
      pathToVideoFile,
      isReturnPathOfIOS: true,
    );
```
Reason was it tries to create a URL from a file path. This fixes the issue by using URL.init(fileURLWithPath) method. 

Haven't used Swift or Objective C, probably there is a better way to do this.