### PR TITLE
fix: Does not crash in debug mode of iOS 14+

### DIFF
--- a/ios/Classes/ImageGallerySaverPlugin.m
+++ b/ios/Classes/ImageGallerySaverPlugin.m
@@ -8,6 +8,8 @@
 
 @implementation ImageGallerySaverPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftImageGallerySaverPlugin registerWithRegistrar:registrar];
+    if (registrar) {
+        [SwiftImageGallerySaverPlugin registerWithRegistrar:registrar];
+    }
 }
 @end


### PR DESCRIPTION
In ios 14+, debug mode Flutter apps can only be launched from Flutter tooling, IDEs with Flutter plugins or from Xcode.
So, registrar will be nil.
However, we can't make it crash in its own plugin.