### PR TITLE
Compact Android scope storage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -25,13 +25,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -64,6 +64,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                 val path = call.argument<String>("file") ?: return
                 val name = call.argument<String>("name")
                 val folder = call.argument<String>("folder")
+                val isImage = call.argument<Boolean>("isImage") ?: true
 
                 if (Build.VERSION.SDK_INT >= 30) {
                     result.success(
@@ -72,6 +73,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                             path,
                             name ?: "",
                             folder ?: "",
+                            isImage,
                         ),
                     )
                 } else {
@@ -213,32 +215,35 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
         filePath: String,
         name: String,
         folder: String,
+        isImage: Boolean = true,
     ): HashMap<String, Any?> {
         var fileName = filePath
         if (filePath.contains('/')) {
             fileName = filePath.substringAfterLast("/")
         }
-        var type = "png"
+        var suffix = "png"
         if (fileName.contains(".")) {
-            type = fileName.substringAfterLast(".")
+            suffix = fileName.substringAfterLast(".", "")
         }
-        val isImage = type.equals("png", ignoreCase = true)
-                || type.equals("webp", ignoreCase = true)
-                || type.equals("jpg", ignoreCase = true)
-                || type.equals("jpeg", ignoreCase = true)
-                || type.equals("heic", ignoreCase = true)
-                || type.equals("gif", ignoreCase = true)
-                || type.equals("apng", ignoreCase = true)
-                || type.equals("raw", ignoreCase = true)
-                || type.equals("svg", ignoreCase = true)
-                || type.equals("bmp", ignoreCase = true)
-                || type.equals("tif", ignoreCase = true)
+        val isImageSuffix = suffix.equals("png", ignoreCase = true)
+                || suffix.equals("webp", ignoreCase = true)
+                || suffix.equals("jpg", ignoreCase = true)
+                || suffix.equals("jpeg", ignoreCase = true)
+                || suffix.equals("heic", ignoreCase = true)
+                || suffix.equals("gif", ignoreCase = true)
+                || suffix.equals("apng", ignoreCase = true)
+                || suffix.equals("raw", ignoreCase = true)
+                || suffix.equals("svg", ignoreCase = true)
+                || suffix.equals("bmp", ignoreCase = true)
+                || suffix.equals("tif", ignoreCase = true)
 
-        filePath.substringAfterLast(".")
+        if (isImage && !isImageSuffix) {
+            suffix = "png"
+        }
         val currentTime: Long = System.currentTimeMillis()
         val imageDate: String =
             SimpleDateFormat("yyyyMMdd-HHmmss", Locale.getDefault()).format(Date(currentTime))
-        val screenshotFileNameTemplate = "%s.$type"
+        val screenshotFileNameTemplate = "%s.$suffix"
         val mImageFileName: String =
             name.ifEmpty { String.format(screenshotFileNameTemplate, imageDate) }
         val values = ContentValues()
@@ -263,7 +268,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
         try {
             values.put(
                 MediaStore.MediaColumns.MIME_TYPE,
-                if (isImage) "image/$type" else "video/$type",
+                if (isImage) "image/$suffix" else "video/$suffix",
             )
         } catch (e: java.lang.Exception) {
         }

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -192,7 +192,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
 
         try {
             resolver.openOutputStream(uri).use { out ->
-                if (!image.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                if (!image.compress(Bitmap.CompressFormat.PNG, 100, out!!)) {
                     return SaveResultModel(false, null, "").toHashMap()
                 }
             }

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -1,55 +1,89 @@
 package com.example.imagegallerysaver
 
+import android.annotation.TargetApi
+import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Environment
 import android.os.Build
+import android.os.Environment
 import android.provider.MediaStore
+import android.text.TextUtils
+import android.text.format.DateUtils
+import android.webkit.MimeTypeMap
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
-import android.text.TextUtils
-import android.webkit.MimeTypeMap
-
+import java.text.SimpleDateFormat
+import java.util.*
 
 class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
     private var applicationContext: Context? = null
     private var methodChannel: MethodChannel? = null
 
-    override fun onMethodCall(call: MethodCall, result: Result): Unit {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when {
             call.method == "saveImageToGallery" -> {
                 val image = call.argument<ByteArray>("imageBytes") ?: return
                 val quality = call.argument<Int>("quality") ?: return
                 val name = call.argument<String>("name")
-
-                result.success(saveImageToGallery(BitmapFactory.decodeByteArray(image, 0, image.size), quality, name))
+                val folder = call.argument<String>("folder")
+                if (Build.VERSION.SDK_INT >= 29) {
+                    result.success(
+                        saveImageToGallery29(
+                            applicationContext!!,
+                            BitmapFactory.decodeByteArray(image, 0, image.size),
+                            name ?: "",
+                            folder = folder ?: "",
+                        ),
+                    )
+                } else {
+                    result.success(
+                        saveImageToGallery(
+                            BitmapFactory.decodeByteArray(
+                                image,
+                                0,
+                                image.size,
+                            ),
+                            quality,
+                            name ?: "",
+                        ),
+                    )
+                }
             }
             call.method == "saveFileToGallery" -> {
                 val path = call.argument<String>("file") ?: return
                 val name = call.argument<String>("name")
-                result.success(saveFileToGallery(path, name))
+                val folder = call.argument<String>("folder")
+
+                if (Build.VERSION.SDK_INT >= 29) {
+                    result.success(
+                        saveFileToGallery29(
+                            applicationContext!!,
+                            path,
+                            name ?: "",
+                            folder ?: "",
+                        ),
+                    )
+                } else {
+                    result.success(saveFileToGallery(path, name))
+                }
             }
             else -> result.notImplemented()
         }
-
     }
-
 
     private fun generateUri(extension: String = "", name: String? = null): Uri {
         var fileName = name ?: System.currentTimeMillis().toString()
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             var uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 
@@ -66,7 +100,8 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
             }
             return applicationContext?.contentResolver?.insert(uri, values)!!
         } else {
-            val storePath = Environment.getExternalStorageDirectory().absolutePath + File.separator + Environment.DIRECTORY_PICTURES
+            val storePath =
+                Environment.getExternalStorageDirectory().absolutePath + File.separator + Environment.DIRECTORY_PICTURES
             val appDir = File(storePath)
             if (!appDir.exists()) {
                 appDir.mkdir()
@@ -79,16 +114,26 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun getMIMEType(extension: String): String? {
-        var type: String? = null;
+        var type: String? = null
         if (!TextUtils.isEmpty(extension)) {
             type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase())
         }
         return type
     }
 
-    private fun saveImageToGallery(bmp: Bitmap, quality: Int, name: String?): HashMap<String, Any?> {
+    private fun saveImageToGallery(
+        bmp: Bitmap,
+        quality: Int,
+        name: String,
+    ): HashMap<String, Any?> {
         val context = applicationContext
-        val fileUri = generateUri("jpg", name = name)
+        val currentTime: Long = System.currentTimeMillis()
+        val imageDate: String =
+            SimpleDateFormat("yyyyMMdd-HHmmss", Locale.getDefault()).format(Date(currentTime))
+        val screenshotFileNameTemplate = "%s.jpg"
+        val imageFileName: String =
+            name.ifEmpty { String.format(screenshotFileNameTemplate, imageDate) }
+        val fileUri = generateUri("jpg", name = imageFileName)
         return try {
             val fos = context?.contentResolver?.openOutputStream(fileUri)!!
             println("ImageGallerySaverPlugin $quality")
@@ -101,6 +146,163 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
         } catch (e: IOException) {
             SaveResultModel(false, null, e.toString()).toHashMap()
         }
+    }
+
+    /**
+     * android 10 以上版本
+     */
+    @TargetApi(Build.VERSION_CODES.Q)
+    fun saveImageToGallery29(
+        context: Context,
+        image: Bitmap,
+        name: String?,
+        folder: String = "",
+    ): HashMap<String, Any?> {
+        val currentTime: Long = System.currentTimeMillis()
+        val imageDate: String =
+            SimpleDateFormat("yyyyMMdd-HHmmss", Locale.getDefault()).format(Date(currentTime))
+        val screenshotFileNameTemplate = "%s.png"
+        val mImageFileName: String = name ?: String.format(screenshotFileNameTemplate, imageDate)
+        val values = ContentValues()
+
+        values.put(
+            MediaStore.MediaColumns.RELATIVE_PATH,
+            if (folder.isEmpty()) {
+                Environment.DIRECTORY_PICTURES
+            } else {
+                "${Environment.DIRECTORY_PICTURES}${File.separator}$folder"
+            },
+        )
+        values.put(MediaStore.MediaColumns.DISPLAY_NAME, mImageFileName)
+        values.put(MediaStore.MediaColumns.MIME_TYPE, "image/png")
+        values.put(MediaStore.MediaColumns.DATE_ADDED, currentTime / 1000)
+        values.put(MediaStore.MediaColumns.DATE_MODIFIED, currentTime / 1000)
+        values.put(
+            MediaStore.MediaColumns.DATE_EXPIRES,
+            (currentTime + DateUtils.DAY_IN_MILLIS) / 1000,
+        )
+        values.put(MediaStore.MediaColumns.IS_PENDING, 1)
+        val resolver: ContentResolver = context.getContentResolver()
+        val uri: Uri? = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+        if (uri == null) return SaveResultModel(false, null, "").toHashMap()
+
+        try {
+            resolver.openOutputStream(uri).use { out ->
+                if (!image.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    return SaveResultModel(false, null, "").toHashMap()
+                }
+            }
+            values.clear()
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+            values.putNull(MediaStore.MediaColumns.DATE_EXPIRES)
+            resolver.update(uri, values, null, null)
+        } catch (e: IOException) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                resolver.delete(uri, null)
+            }
+            return SaveResultModel(false, null, "").toHashMap()
+        }
+        return SaveResultModel(true, null, "").toHashMap()
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    private fun saveFileToGallery29(
+        context: Context,
+        filePath: String,
+        name: String,
+        folder: String,
+    ): HashMap<String, Any?> {
+        var fileName = filePath
+        if (filePath.contains('/')) {
+            fileName = filePath.substringAfterLast("/")
+        }
+        var type = "png"
+        if (fileName.contains(".")) {
+            type = fileName.substringAfterLast(".")
+        }
+        val isImage = type.equals("png", ignoreCase = true) ||
+            type.equals("webp", ignoreCase = true) ||
+            type.equals("jpg", ignoreCase = true) ||
+            type.equals("jpeg", ignoreCase = true) ||
+            type.equals("heic", ignoreCase = true)
+        type.equals("gif", ignoreCase = true)
+        type.equals("apng", ignoreCase = true)
+        type.equals("raw", ignoreCase = true)
+        type.equals("svg", ignoreCase = true)
+        type.equals("bmp", ignoreCase = true)
+        type.equals("tif", ignoreCase = true)
+
+        filePath.substringAfterLast(".")
+        val currentTime: Long = System.currentTimeMillis()
+        val imageDate: String =
+            SimpleDateFormat("yyyyMMdd-HHmmss", Locale.getDefault()).format(Date(currentTime))
+        val screenshotFileNameTemplate = "%s.$type"
+        val mImageFileName: String =
+            name.ifEmpty { String.format(screenshotFileNameTemplate, imageDate) }
+        val values = ContentValues()
+
+        values.put(
+            MediaStore.MediaColumns.RELATIVE_PATH,
+            if (folder.isEmpty()) {
+                if (isImage) {
+                    Environment.DIRECTORY_PICTURES
+                } else {
+                    Environment.DIRECTORY_MOVIES
+                }
+            } else {
+                if (isImage) {
+                    "${Environment.DIRECTORY_PICTURES}${File.separator}$folder"
+                } else {
+                    "${Environment.DIRECTORY_MOVIES}${File.separator}$folder"
+                }
+            },
+        )
+        values.put(MediaStore.MediaColumns.DISPLAY_NAME, mImageFileName)
+        try {
+            values.put(
+                MediaStore.MediaColumns.MIME_TYPE,
+                if (isImage) "image/$type" else "video/$type",
+            )
+        } catch (e: java.lang.Exception) {
+        }
+        values.put(MediaStore.MediaColumns.DATE_ADDED, currentTime / 1000)
+        values.put(MediaStore.MediaColumns.DATE_MODIFIED, currentTime / 1000)
+        values.put(
+            MediaStore.MediaColumns.DATE_EXPIRES,
+            (currentTime + DateUtils.DAY_IN_MILLIS) / 1000,
+        )
+        values.put(MediaStore.MediaColumns.IS_PENDING, 1)
+        val resolver: ContentResolver = context.getContentResolver()
+        val uri: Uri? = resolver.insert(
+            if (isImage) {
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+            } else {
+                MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+            },
+            values,
+        )
+        if (uri == null) return SaveResultModel(false, null, "").toHashMap()
+        try {
+            val fileInputStream = FileInputStream(filePath)
+            val data = ByteArray(1024)
+            var read = 0
+            resolver.openOutputStream(uri).use { out ->
+                while ((fileInputStream.read(data, 0, data.size).also { read = it }) != -1) {
+                    out?.write(data, 0, read)
+                }
+            }
+            values.clear()
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+            values.putNull(MediaStore.MediaColumns.DATE_EXPIRES)
+            fileInputStream.close()
+            resolver.update(uri, values, null, null)
+        } catch (e: IOException) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                resolver.delete(uri, null)
+            }
+            return SaveResultModel(false, null, "").toHashMap()
+        }
+        return SaveResultModel(true, null, "").toHashMap()
     }
 
     private fun saveFileToGallery(filePath: String, name: String?): HashMap<String, Any?> {
@@ -135,8 +337,8 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         applicationContext = null
-        methodChannel!!.setMethodCallHandler(null);
-        methodChannel = null;
+        methodChannel!!.setMethodCallHandler(null)
+        methodChannel = null
     }
 
     private fun onAttachedToEngine(applicationContext: Context, messenger: BinaryMessenger) {
@@ -144,12 +346,13 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
         methodChannel = MethodChannel(messenger, "image_gallery_saver")
         methodChannel!!.setMethodCallHandler(this)
     }
-
 }
 
-class SaveResultModel(var isSuccess: Boolean,
-                      var filePath: String? = null,
-                      var errorMessage: String? = null) {
+class SaveResultModel(
+    var isSuccess: Boolean,
+    var filePath: String? = null,
+    var errorMessage: String? = null,
+) {
     fun toHashMap(): HashMap<String, Any?> {
         val hashMap = HashMap<String, Any?>()
         hashMap["isSuccess"] = isSuccess

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -36,9 +36,9 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                 val quality = call.argument<Int>("quality") ?: return
                 val name = call.argument<String>("name")
                 val folder = call.argument<String>("folder")
-                if (Build.VERSION.SDK_INT >= 29) {
+                if (Build.VERSION.SDK_INT >= 30) {
                     result.success(
-                        saveImageToGallery29(
+                        saveImageToGallery30(
                             applicationContext!!,
                             BitmapFactory.decodeByteArray(image, 0, image.size),
                             name ?: "",
@@ -59,14 +59,15 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                     )
                 }
             }
+
             call.method == "saveFileToGallery" -> {
                 val path = call.argument<String>("file") ?: return
                 val name = call.argument<String>("name")
                 val folder = call.argument<String>("folder")
 
-                if (Build.VERSION.SDK_INT >= 29) {
+                if (Build.VERSION.SDK_INT >= 30) {
                     result.success(
-                        saveFileToGallery29(
+                        saveFileToGallery30(
                             applicationContext!!,
                             path,
                             name ?: "",
@@ -77,6 +78,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                     result.success(saveFileToGallery(path, name))
                 }
             }
+
             else -> result.notImplemented()
         }
     }
@@ -152,7 +154,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
      * android 10 以上版本
      */
     @TargetApi(Build.VERSION_CODES.Q)
-    fun saveImageToGallery29(
+    fun saveImageToGallery30(
         context: Context,
         image: Bitmap,
         name: String?,
@@ -206,7 +208,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
-    private fun saveFileToGallery29(
+    private fun saveFileToGallery30(
         context: Context,
         filePath: String,
         name: String,
@@ -220,17 +222,17 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
         if (fileName.contains(".")) {
             type = fileName.substringAfterLast(".")
         }
-        val isImage = type.equals("png", ignoreCase = true) ||
-            type.equals("webp", ignoreCase = true) ||
-            type.equals("jpg", ignoreCase = true) ||
-            type.equals("jpeg", ignoreCase = true) ||
-            type.equals("heic", ignoreCase = true)
-        type.equals("gif", ignoreCase = true)
-        type.equals("apng", ignoreCase = true)
-        type.equals("raw", ignoreCase = true)
-        type.equals("svg", ignoreCase = true)
-        type.equals("bmp", ignoreCase = true)
-        type.equals("tif", ignoreCase = true)
+        val isImage = type.equals("png", ignoreCase = true)
+                || type.equals("webp", ignoreCase = true)
+                || type.equals("jpg", ignoreCase = true)
+                || type.equals("jpeg", ignoreCase = true)
+                || type.equals("heic", ignoreCase = true)
+                || type.equals("gif", ignoreCase = true)
+                || type.equals("apng", ignoreCase = true)
+                || type.equals("raw", ignoreCase = true)
+                || type.equals("svg", ignoreCase = true)
+                || type.equals("bmp", ignoreCase = true)
+                || type.equals("tif", ignoreCase = true)
 
         filePath.substringAfterLast(".")
         val currentTime: Long = System.currentTimeMillis()

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -230,6 +230,7 @@ class ImageGallerySaverPlugin : FlutterPlugin, MethodCallHandler {
                 || suffix.equals("jpg", ignoreCase = true)
                 || suffix.equals("jpeg", ignoreCase = true)
                 || suffix.equals("heic", ignoreCase = true)
+                || suffix.equals("heif", ignoreCase = true)
                 || suffix.equals("gif", ignoreCase = true)
                 || suffix.equals("apng", ignoreCase = true)
                 || suffix.equals("raw", ignoreCase = true)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -43,8 +43,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.imagegallerysaverexample"
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
          flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
@@ -15,15 +15,15 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="${applicationName}"
-        android:label="image_gallery_saver_example"
-        android:requestLegacyExternalStorage="true"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:label="image_gallery_saver_example">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
+            android:exported="true"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
-            android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- This keeps the window background of the activity showing
                  until Flutter renders its first frame. It can be removed if
@@ -33,8 +33,8 @@
                 android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
                 android:value="true" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <meta-data

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -114,8 +114,9 @@ class _MyHomePageState extends State<MyHomePage> {
     ByteData? byteData =
         await (image.toByteData(format: ui.ImageByteFormat.png));
     if (byteData != null) {
-      final result =
-          await ImageGallerySaver.saveImage(byteData.buffer.asUint8List());
+      final result = await ImageGallerySaver.saveImage(
+          byteData.buffer.asUint8List(),
+          folder: "SaveImageToGallery");
       print(result);
       _toastInfo(result.toString());
     }
@@ -128,6 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
     final result = await ImageGallerySaver.saveImage(
         Uint8List.fromList(response.data),
         quality: 60,
+        folder: "SaveImageToGallery",
         name: "hello");
     print(result);
     _toastInfo("$result");
@@ -139,7 +141,8 @@ class _MyHomePageState extends State<MyHomePage> {
     String fileUrl =
         "https://hyjdoc.oss-cn-beijing.aliyuncs.com/hyj-doc-flutter-demo-run.gif";
     await Dio().download(fileUrl, savePath);
-    final result = await ImageGallerySaver.saveFile(savePath);
+    final result = await ImageGallerySaver.saveFile(savePath,
+        folder: "SaveImageToGallery");
     print(result);
     _toastInfo("$result");
   }
@@ -148,11 +151,12 @@ class _MyHomePageState extends State<MyHomePage> {
     var appDocDir = await getTemporaryDirectory();
     String savePath = appDocDir.path + "/temp.mp4";
     String fileUrl =
-        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4";
+        "http://vfx.mtime.cn/Video/2019/02/04/mp4/190204084208765161.mp4";
     await Dio().download(fileUrl, savePath, onReceiveProgress: (count, total) {
       print((count / total * 100).toStringAsFixed(0) + "%");
     });
-    final result = await ImageGallerySaver.saveFile(savePath);
+    final result = await ImageGallerySaver.saveFile(savePath,
+        folder: "SaveImageToGallery-Video");
     print(result);
     _toastInfo("$result");
   }

--- a/lib/image_gallery_saver.dart
+++ b/lib/image_gallery_saver.dart
@@ -14,23 +14,27 @@ class ImageGallerySaver {
   static FutureOr<dynamic> saveImage(Uint8List imageBytes,
       {int quality = 80,
       String? name,
+      String? folder,
       bool isReturnImagePathOfIOS = false}) async {
     final result =
         await _channel.invokeMethod('saveImageToGallery', <String, dynamic>{
       'imageBytes': imageBytes,
       'quality': quality,
       'name': name,
+      'folder': folder,
       'isReturnImagePathOfIOS': isReturnImagePathOfIOS
     });
     return result;
   }
 
   /// Save the PNG，JPG，JPEG image or video located at [file] to the local device media gallery.
-  static Future saveFile(String file, {String? name, bool isReturnPathOfIOS = false}) async {
-    final result = await _channel.invokeMethod(
-        'saveFileToGallery', <String, dynamic>{
+  static Future saveFile(String file,
+      {String? name, String? folder, bool isReturnPathOfIOS = false}) async {
+    final result =
+        await _channel.invokeMethod('saveFileToGallery', <String, dynamic>{
       'file': file,
       'name': name,
+      'folder': folder,
       'isReturnPathOfIOS': isReturnPathOfIOS
     });
     return result;

--- a/lib/image_gallery_saver.dart
+++ b/lib/image_gallery_saver.dart
@@ -29,12 +29,16 @@ class ImageGallerySaver {
 
   /// Save the PNG，JPG，JPEG image or video located at [file] to the local device media gallery.
   static Future saveFile(String file,
-      {String? name, String? folder, bool isReturnPathOfIOS = false}) async {
+      {String? name,
+      String? folder,
+      bool isImage = true,
+      bool isReturnPathOfIOS = false}) async {
     final result =
         await _channel.invokeMethod('saveFileToGallery', <String, dynamic>{
       'file': file,
       'name': name,
       'folder': folder,
+      'isImage': isImage,
       'isReturnPathOfIOS': isReturnPathOfIOS
     });
     return result;


### PR DESCRIPTION
- 兼容 Android 29 scope storage
- 没找到如何在运行时获取 requestLegacyExternalStorage 的方法，判断方法被系统标为 @Hide，直接一刀切禁用 requestLegacyExternalStorage，>= 29 都使用 scope storage
- 保存时增加 文件夹 参数
- 升级 example 适配 android 33