### PR TITLE
Add iOS privacy manifests file

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/image_gallery_saver.podspec
+++ b/ios/image_gallery_saver.podspec
@@ -18,6 +18,7 @@ A new flutter plugin project.
 
   s.ios.deployment_target = '8.0'
   s.swift_version = '5.0'
+  s.resource_bundles = {'image_gallery_saver_privacy' => ['PrivacyInfo.xcprivacy']}
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
 


### PR DESCRIPTION
## Related Issue

Fixes https://github.com/hui-z/image_gallery_saver/issues/285

## Description

Added `PrivacyInfo.xcprivacy` to podspec of flutter-devicelocale.
I think image_gallery_saver is internally calling `UIImageWriteToSavedPhotosAlbum`, however it seems like not directly collect any user data, so I created an empty privacy manifests file.