### PR TITLE
In case of restricted access to the assets provide a proper result

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException

--- a/ios/Classes/SwiftImageGallerySaverPlugin.swift
+++ b/ios/Classes/SwiftImageGallerySaverPlugin.swift
@@ -145,6 +145,11 @@ public class SwiftImageGallerySaverPlugin: NSObject, FlutterPlugin {
                             }
                         }
                     }
+                    // PHAuthorizationStatus restricts access to asset
+                    // save the result otherwise this will result in a never ending await at the flutter side
+                    else {
+                        self.saveResult(isSuccess: false, error: self.errorMessage)
+                    }
                 } else {
                     self.saveResult(isSuccess: false, error: self.errorMessage)
                 }

--- a/ios/Classes/SwiftImageGallerySaverPlugin.swift
+++ b/ios/Classes/SwiftImageGallerySaverPlugin.swift
@@ -103,6 +103,11 @@ public class SwiftImageGallerySaverPlugin: NSObject, FlutterPlugin {
                             }
                         }
                     }
+                    // PHAuthorizationStatus restricts access to asset
+                    // save the result otherwise this will result in a never ending await at the flutter side
+                    else {
+                        self.saveResult(isSuccess: false, error: self.errorMessage)
+                    }
                 } else {
                     self.saveResult(isSuccess: false, error: self.errorMessage)
                 }


### PR DESCRIPTION
![image](https://github.com/hui-z/image_gallery_saver/assets/8133838/27a71ba3-4e23-48e2-9cf8-83518a4475dd)

If the "Allow photo access" option under app settings is set to "Add photos only" the call to PHAsset.fetchAssets will result in an assetResult with count = 0.
This results in a never ending await on the flutter side because saveResult is never called.