### PR TITLE
🔥[Urgent] Support AGP 8, SDK 34, Flutter 3.29 compatible

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,20 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.example.imagegallerysaver'
+    }
+    
     compileSdkVersion 30
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         namespace 'com.example.imagegallerysaver'
     }
     
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,6 +45,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException


### PR DESCRIPTION
1. Support AGP 8
2. Fix Compile Issue #272
3. Flutter 3.29 compatible

For people who are waiting for this 

### Option 1: Use new package
[flutter_image_gallery_saver](https://pub.dev/packages/flutter_image_gallery_saver)
```yaml
dependencies:
  flutter_image_gallery_saver: ^0.0.2
 ```
 

### Option 2: override this package in your `pubspec.yaml`
```yaml
dependency_overrides:
  image_gallery_saver:
    git:
      url: https://github.com/knottx/image_gallery_saver.git
      ref: knottx-latest
```