### PR TITLE
Removes references to Flutter v1 android embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+- Removes references to Flutter v1 android embedding classes.
+
 ## 2.0.3
 - 1.Upgrade flutter version to 3.10.5
 - 2.Android build tools are upgraded to 7.3.0

--- a/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
+++ b/android/src/main/kotlin/com/example/imagegallerysaver/ImageGallerySaverPlugin.kt
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="${applicationName}"
         android:label="image_gallery_saver_example"
         android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher">

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  permission_handler: ^10.3.0
+  permission_handler: ^11.3.1
   fluttertoast: ^8.2.2
   path_provider: ^2.0.15
   dio: ^5.2.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_gallery_saver
 description: A flutter plugin for save image to gallery, iOS need to add the following keys to your Info.plist file.
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/hui-z/image_gallery_saver
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/hui-z/image_gallery_saver/issues/309.

Tested by building the image_gallery_saver example app with the changes in https://github.com/flutter/engine/pull/52022 applied.

The example app depends on FlutterToast, which is still pending a PR for these same changes. As such, the example app will not build with the above engine changes applied until those changes to FlutterToast land and publish. FlutterToast is not a dependency of the image_gallery_saver plugin itself, so uses of the plugin will not be affected.