### PR TITLE
Add namespace to android build.gradle to comply with AGP 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.example.image_gallery_saver'
+    
     compileSdkVersion 30
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,9 @@ android {
     namespace 'com.example.image_gallery_saver'
     
     compileSdkVersion 30
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.imagegallerysaver">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">


### PR DESCRIPTION
Namespace not specified. Specify a namespace in the module's build file (
...means the image_gallery_saver package (or a fork of it) doesn't specify the namespace in its android/build.gradle file, which is required with newer versions of the Android Gradle Plugin (AGP 8+).
)